### PR TITLE
Used border instead of background color, and adjusted vertical positi…

### DIFF
--- a/src/style/app.scss
+++ b/src/style/app.scss
@@ -335,10 +335,11 @@ $button-hover-color: #f6f5f5;
           margin: 0.15rem 0 0.1rem 0;
           &::after {
             content: "";
+            position: relative;
+            top: 2.5px;
             flex: 1 1 auto;
-            height: 1px;
+            border-bottom: 1px solid $divide-line-color;
             margin-left: 0.2rem;
-            background-color: $divide-line-color;
           }
         }
         .title {


### PR DESCRIPTION
<img width="625" alt="before" src="https://github.com/LynanBreeze/simple-resume/assets/100430036/a9629952-2eaa-486e-a87a-6edd2b863381">

As you can in the image, section border lines' width is not consistence across the page despite its value being 1px everywhere, i checked this issue in different browsers and it tends to exist, an unexpected css behaviour i suppose, anyways using border-bottom fixed the issue as you can see here : 

<img width="644" alt="after" src="https://github.com/LynanBreeze/simple-resume/assets/100430036/1bd0aec5-dd21-48b4-b88b-f7e4aae2afe9">

and also replaced the border's vertical position and brought it a little bit lower, now its in the center, compare images : 

**before :** 

<img width="246" alt="before-1" src="https://github.com/LynanBreeze/simple-resume/assets/100430036/efd0de65-6abf-478b-9526-56b5dc8a2232">

**after :**

<img width="317" alt="after 1" src="https://github.com/LynanBreeze/simple-resume/assets/100430036/b7a5109e-0d0f-4b5a-b2ee-d238d94a7dbc">

